### PR TITLE
add missing unsnoc def

### DIFF
--- a/src/Solcore/Desugarer/MatchCompiler.hs
+++ b/src/Solcore/Desugarer/MatchCompiler.hs
@@ -198,6 +198,12 @@ fifthCase es@(_ : _) d eqns@(_ : eqs)
           d' <- generateFunctions es d eqs 
           matchCompilerM es d' eq 
         Nothing -> throwError "Panic! Impossible --- fifthCase"
+    where
+      unsnoc [] = Nothing
+      unsnoc [x] = Just ([], x)
+      unsnoc (x:xs) = do
+        (ys, y) <- unsnoc xs
+        pure (x:ys, y)
 
 hasVarsBetweenConstrs :: Equations -> Bool
 hasVarsBetweenConstrs eqns 


### PR DESCRIPTION
Added missing definition of usnoc in `Solcore.Desugarer.MatchCompiler.fifthCase`
to fix the following error:

```
src/Solcore/Desugarer/MatchCompiler.hs:196:12: error:
    Variable not in scope:
      unsnoc :: [[([Pat], [Stmt])]] -> Maybe ([Equations], Equations)
    |
196 |       case unsnoc eqnss of
    |            ^^^^^^
```