### PR TITLE
Add alex and happy as build-tool-depends

### DIFF
--- a/sol-core.cabal
+++ b/sol-core.cabal
@@ -22,9 +22,11 @@ common common-opts
     , containers
     , fgl
     , array
-    , pretty 
+    , pretty
     , optparse-applicative
     , syb
+  build-tool-depends: happy:happy, alex:alex
+
   default-language: Haskell2010
   default-extensions: OverloadedStrings
                       FlexibleInstances
@@ -48,9 +50,9 @@ library
       Solcore.Frontend.Parser.SolcoreParser
       Solcore.Frontend.Pretty.SolcorePretty
       Solcore.Frontend.Syntax
-      Solcore.Frontend.Syntax.Ty 
+      Solcore.Frontend.Syntax.Ty
       Solcore.Frontend.Syntax.Contract
-      Solcore.Frontend.Syntax.Name 
+      Solcore.Frontend.Syntax.Name
       Solcore.Frontend.Syntax.Stmt
       Solcore.Frontend.TypeInference.Id
       Solcore.Frontend.TypeInference.NameSupply


### PR DESCRIPTION
`nix build .` is currently failing because these are missing.