### PR TITLE
Unify pretty-printing

### DIFF
--- a/src/Common/Pretty.hs
+++ b/src/Common/Pretty.hs
@@ -15,4 +15,4 @@ infixl 6 ><
 (><) = (PP.<>)
 
 class Pretty a where
-  pretty :: a -> Doc
+  ppr :: a -> Doc

--- a/src/Language/Core.hs
+++ b/src/Language/Core.hs
@@ -25,7 +25,7 @@ data Expr
     | ECall Name [Expr]
     | EUnit
 instance Show Expr where
-    show = render . pretty
+    show = render . ppr
 
 pattern SAV :: Name -> Expr -> Stmt
 pattern SAV x e = SAssign (EVar x) e
@@ -43,53 +43,53 @@ data Stmt
     -- deriving Show
 
 data Arg = TArg Name Type
-instance Show Stmt where show = render . pretty
+instance Show Stmt where show = render . ppr
 
 data Alt = Alt Name Stmt
 
 newtype Core = Core [Stmt]
-instance Show Core where show = render . pretty
+instance Show Core where show = render . ppr
 
 instance Pretty Type where
-    pretty TWord = text "word"
-    pretty TBool = text "bool"
-    pretty TUnit = text "unit"
-    pretty (TPair t1 t2) = parens (pretty t1 <+> text "*" <+> pretty t2)
-    pretty (TSum t1 t2) = parens (pretty t1 <+> text "+" <+> pretty t2)
-    pretty (TFun ts t) = parens (hsep (map pretty ts) <+> text "->" <+> pretty t)
+    ppr TWord = text "word"
+    ppr TBool = text "bool"
+    ppr TUnit = text "unit"
+    ppr (TPair t1 t2) = parens (ppr t1 <+> text "*" <+> ppr t2)
+    ppr (TSum t1 t2) = parens (ppr t1 <+> text "+" <+> ppr t2)
+    ppr (TFun ts t) = parens (hsep (map ppr ts) <+> text "->" <+> ppr t)
 
 instance Pretty Expr where
-    pretty (EWord i) = text (show i)
-    pretty (EBool b) = text (show b)
-    pretty EUnit = text "()"
-    pretty (EVar x) = text x
-    pretty (EPair e1 e2) = parens (pretty e1 >< comma <+> pretty e2)
-    pretty (EFst e) = text "fst" >< parens (pretty e)
-    pretty (ESnd e) = text "snd" >< parens (pretty e)
-    pretty (EInl e) = text "inl" >< parens (pretty e)
-    pretty (EInr e) = text "inr" >< parens (pretty e)
-    pretty (ECall f es) = text f >< parens(hsep (punctuate comma (map pretty es)))
+    ppr (EWord i) = text (show i)
+    ppr (EBool b) = text (show b)
+    ppr EUnit = text "()"
+    ppr (EVar x) = text x
+    ppr (EPair e1 e2) = parens (ppr e1 >< comma <+> ppr e2)
+    ppr (EFst e) = text "fst" >< parens (ppr e)
+    ppr (ESnd e) = text "snd" >< parens (ppr e)
+    ppr (EInl e) = text "inl" >< parens (ppr e)
+    ppr (EInr e) = text "inr" >< parens (ppr e)
+    ppr (ECall f es) = text f >< parens(hsep (punctuate comma (map ppr es)))
 
 instance Pretty Stmt where
-    pretty (SAssign lhs rhs) = pretty lhs <+> text ":=" <+> pretty rhs
-    pretty (SAlloc x t) = text "let" <+> text x <+> text ":" <+> pretty t
-    pretty (SExpr e) = pretty e
-    pretty (SAssembly stmts) = vcat (map pretty stmts)
-    pretty (SReturn e) = text "return" <+> pretty e
-    pretty (SComment c) = text "//" <+> text c
-    pretty (SBlock stmts) = lbrace $$ nest 4 (vcat (map pretty stmts)) $$ rbrace
-    pretty (SMatch e [left, right]) =
-        text "match" <+> pretty e <+> text "with" $$ lbrace
+    ppr (SAssign lhs rhs) = ppr lhs <+> text ":=" <+> ppr rhs
+    ppr (SAlloc x t) = text "let" <+> text x <+> text ":" <+> ppr t
+    ppr (SExpr e) = ppr e
+    ppr (SAssembly stmts) = vcat (map ppr stmts)
+    ppr (SReturn e) = text "return" <+> ppr e
+    ppr (SComment c) = text "//" <+> text c
+    ppr (SBlock stmts) = lbrace $$ nest 4 (vcat (map ppr stmts)) $$ rbrace
+    ppr (SMatch e [left, right]) =
+        text "match" <+> ppr e <+> text "with" $$ lbrace
            $$ nest 2 (vcat [prettyAlt "inl" left, prettyAlt "inr" right]) $$ rbrace
         where
-            prettyAlt tag (Alt n s) = text tag <+> text n <+> text "=>" <+> pretty s
-    pretty (SFunction f args ret stmts) =
-        text "function" <+> text f <+> parens (hsep (punctuate comma (map pretty args))) <+> text "->" <+> pretty ret <+> lbrace
-           $$ nest 2 (vcat (map pretty stmts))  $$ rbrace
-    pretty (SRevert s) = text "revert" <+> text s
+            prettyAlt tag (Alt n s) = text tag <+> text n <+> text "=>" <+> ppr s
+    ppr (SFunction f args ret stmts) =
+        text "function" <+> text f <+> parens (hsep (punctuate comma (map ppr args))) <+> text "->" <+> ppr ret <+> lbrace
+           $$ nest 2 (vcat (map ppr stmts))  $$ rbrace
+    ppr (SRevert s) = text "revert" <+> text s
 
 instance Pretty Arg where
-    pretty (TArg n t) = text n <+> text ":" <+> pretty t
+    ppr (TArg n t) = text n <+> text ":" <+> ppr t
 
 instance Pretty Core where
-    pretty (Core stmts) = vcat (map pretty stmts)
+    ppr (Core stmts) = vcat (map ppr stmts)

--- a/src/Language/Yul.hs
+++ b/src/Language/Yul.hs
@@ -3,10 +3,10 @@ module Language.Yul where
 import Common.Pretty
 
 newtype Yul = Yul { yulStmts :: [YulStatement] }
-instance Show Yul where show = render . pretty
-instance Show YulStatement where show = render . pretty
-instance Show YulExpression where show = render . pretty
-instance Show YulLiteral where show = render . pretty
+instance Show Yul where show = render . ppr
+instance Show YulStatement where show = render . ppr
+instance Show YulExpression where show = render . ppr
+instance Show YulLiteral where show = render . ppr
 
 type Name = String
 type YArg = Name
@@ -53,55 +53,55 @@ yulBool True = YulLiteral YulTrue
 yulBool False = YulLiteral YulFalse
 
 instance Pretty Yul where
-  pretty (Yul stmts) = vcat (map pretty stmts)
+  ppr (Yul stmts) = vcat (map ppr stmts)
 
 instance Pretty YulStatement where
-  pretty (YulBlock stmts) =
+  ppr (YulBlock stmts) =
     lbrace
-      $$ nest 4 (vcat (map pretty stmts))
+      $$ nest 4 (vcat (map ppr stmts))
       $$ rbrace
-  pretty (YulFun name args rets stmts) =
+  ppr (YulFun name args rets stmts) =
     text "function"
       <+> text name
       <+> prettyargs
       <+> prettyrets rets
       <+> lbrace
-      $$ nest 4 (vcat (map pretty stmts))
+      $$ nest 4 (vcat (map ppr stmts))
       $$ rbrace
     where
         prettyargs = parens (hsep (punctuate comma (map text args)))
         prettyrets Nothing = empty
         prettyrets (Just rs) = text "->" <+> (hsep (punctuate comma (map text rs)))
-  pretty (YulLet vars expr) =
+  ppr (YulLet vars expr) =
     text "let" <+> hsep (punctuate comma (map text vars))
-               <+> maybe empty (\e -> text ":=" <+> pretty e) expr
-  pretty (YulAssign vars expr) = hsep (punctuate comma (map text vars)) <+> text ":=" <+> pretty expr
-  pretty (YulIf cond stmts) = text "if" <+> parens (pretty cond) <+> pretty (YulBlock stmts)
-  pretty (YulSwitch expr cases def) =
+               <+> maybe empty (\e -> text ":=" <+> ppr e) expr
+  ppr (YulAssign vars expr) = hsep (punctuate comma (map text vars)) <+> text ":=" <+> ppr expr
+  ppr (YulIf cond stmts) = text "if" <+> parens (ppr cond) <+> ppr (YulBlock stmts)
+  ppr (YulSwitch expr cases def) =
     text "switch"
-      <+> (pretty expr)
-      $$ nest 4 (vcat (map (\(lit, stmts) -> text "case" <+> pretty lit <+> pretty (YulBlock stmts)) cases))
-      $$ maybe empty (\stmts -> text "default" <+> pretty (YulBlock stmts)) def
-  pretty (YulForLoop pre cond post stmts) =
-    text "for" <+> braces (hsep  (map pretty pre))
-               <+> pretty cond
-               <+> hsep (map pretty post) <+> pretty (YulBlock stmts)
-  pretty YulBreak = text "break"
-  pretty YulContinue = text "continue"
-  pretty YulLeave = text "leave"
-  pretty (YulComment c) = text "/*" <+> text c <+> text "*/"
-  pretty (YulExpression e) = pretty e
+      <+> (ppr expr)
+      $$ nest 4 (vcat (map (\(lit, stmts) -> text "case" <+> ppr lit <+> ppr (YulBlock stmts)) cases))
+      $$ maybe empty (\stmts -> text "default" <+> ppr (YulBlock stmts)) def
+  ppr (YulForLoop pre cond post stmts) =
+    text "for" <+> braces (hsep  (map ppr pre))
+               <+> ppr cond
+               <+> hsep (map ppr post) <+> ppr (YulBlock stmts)
+  ppr YulBreak = text "break"
+  ppr YulContinue = text "continue"
+  ppr YulLeave = text "leave"
+  ppr (YulComment c) = text "/*" <+> text c <+> text "*/"
+  ppr (YulExpression e) = ppr e
 
 instance Pretty YulExpression where
-  pretty (YulCall name args) = text name >< parens (hsep (punctuate comma (map pretty args)))
-  pretty (YulIdentifier name) = text name
-  pretty (YulLiteral lit) = pretty lit
+  ppr (YulCall name args) = text name >< parens (hsep (punctuate comma (map ppr args)))
+  ppr (YulIdentifier name) = text name
+  ppr (YulLiteral lit) = ppr lit
 
 instance Pretty YulLiteral where
-  pretty (YulNumber n) = integer n
-  pretty (YulString s) = doubleQuotes (text s)
-  pretty YulTrue = text "true"
-  pretty YulFalse = text "false"
+  ppr (YulNumber n) = integer n
+  ppr (YulString s) = doubleQuotes (text s)
+  ppr YulTrue = text "true"
+  ppr YulFalse = text "false"
 
 {- | wrap a Yul chunk in a Solidity function with the given name
    assumes result is in a variable named "_result"
@@ -112,7 +112,7 @@ wrapInSolFunction name yul = text "function" <+> text name <+> prettyargs <+> te
   $$ rbrace
   where
     assembly = text "assembly" <+> lbrace
-      $$ nest 2 (pretty yul)
+      $$ nest 2 (ppr yul)
       $$ rbrace
     prettyargs = parens empty
 

--- a/src/Solcore/Frontend/Pretty/SolcorePretty.hs
+++ b/src/Solcore/Frontend/Pretty/SolcorePretty.hs
@@ -1,4 +1,4 @@
-module Solcore.Frontend.Pretty.SolcorePretty where 
+module Solcore.Frontend.Pretty.SolcorePretty(module Common.Pretty, pretty) where
 
 import Data.List
 
@@ -11,15 +11,16 @@ import Solcore.Frontend.Syntax.Ty
 import Solcore.Frontend.TypeInference.NameSupply
 import Solcore.Frontend.TypeInference.TcSubst 
 
-import Text.PrettyPrint.HughesPJ
+import Common.Pretty
+
+-- For compatibility
+(<>) :: Doc -> Doc -> Doc
+(<>) = (><)
 
 -- top level pretty printer function 
 
 pretty :: Pretty a => a -> String 
 pretty = render . ppr
-
-class Pretty a where 
-  ppr :: a -> Doc  
 
 instance Pretty a => Pretty (Qual a) where 
   ppr (ps :=> t) 

--- a/src/Solcore/Frontend/TypeInference/Id.hs
+++ b/src/Solcore/Frontend/TypeInference/Id.hs
@@ -2,8 +2,6 @@ module Solcore.Frontend.TypeInference.Id where
 
 import Data.Generics (Data, Typeable)
 
-import Text.PrettyPrint.HughesPJ (text, (<+>), empty)
-
 import Solcore.Frontend.Pretty.SolcorePretty
 import Solcore.Frontend.Syntax
 import Solcore.Frontend.TypeInference.TcSubst 

--- a/src/Solcore/Frontend/TypeInference/TcMonad.hs
+++ b/src/Solcore/Frontend/TypeInference/TcMonad.hs
@@ -8,7 +8,7 @@ import Data.List
 import Data.Map (Map)
 import qualified Data.Map as Map
 
-import Solcore.Frontend.Pretty.SolcorePretty
+import Solcore.Frontend.Pretty.SolcorePretty hiding((<>))
 import Solcore.Frontend.Syntax
 import Solcore.Frontend.TypeInference.NameSupply
 import Solcore.Frontend.TypeInference.TcEnv

--- a/src/Solcore/Frontend/TypeInference/TcUnify.hs
+++ b/src/Solcore/Frontend/TypeInference/TcUnify.hs
@@ -6,7 +6,8 @@ import Data.List
 
 import Solcore.Frontend.Syntax
 import Solcore.Frontend.TypeInference.TcSubst
-import Solcore.Frontend.Pretty.SolcorePretty 
+import Common.Pretty
+import Solcore.Frontend.Pretty.SolcorePretty  hiding((<>))
 
 
 -- standard unification machinery 

--- a/yule/Main.hs
+++ b/yule/Main.hs
@@ -46,7 +46,7 @@ main = do
     let core = parseCore src
     when (verbose options) $ do
         putStrLn "/* Core:"
-        putStrLn (render (nest 2 (pretty core)))
+        putStrLn (render (nest 2 (ppr core)))
         putStrLn "*/"
     generatedYul <- runTM (translateCore core)
     let fooFun = wrapInSolFunction "wrapper" generatedYul


### PR DESCRIPTION
First part of the code base unification effort (see Issue #13)
This PR attempt to unify pretty-printing

- terminology of SolcorePretty (ppr, pretty) is maintained
- class Pretty moved to module Common.Pretty
- engine switched to Text.PrettyPrint used so far by yule, because it outputs actual Solidity/Yul code and its behaviour should be kept.